### PR TITLE
Sprachauswahl für Nutzer #42

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -5,12 +5,8 @@ APP_DEBUG=true
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost
 
-DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
-DB_PORT=3306
-DB_DATABASE=siwecos_business_api
-DB_USERNAME=siwecos
-DB_PASSWORD=n0ucav3z
+DB_CONNECTION=sqlite
+DB_HOST=":memory:"
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
@@ -33,5 +29,5 @@ PUSHER_APP_ID=
 PUSHER_APP_KEY=
 PUSHER_APP_SECRET=
 
-CORE_URL=http://siwecos-core-api.dev
-CORE_MASTER_TOKEN=RIdHtlCq9p1iQD2I3DLPwZV0
+CORE_URL=http://siwecos-core-api
+CORE_MASTER_TOKEN=

--- a/app/Http/Controllers/SiwecosUserController.php
+++ b/app/Http/Controllers/SiwecosUserController.php
@@ -36,29 +36,6 @@ class SiwecosUserController extends Controller
      * @param CreateUserRequest $request
      *
      * @return UserTokenResponse|mixed
-     * @SWG\Post(
-     *   path="/users/create",
-     *   summary="create user",
-     *   operationId="create",
-     *   tags={"users"},
-     *   produces={"application/json"},
-     *   @SWG\Parameter(
-     *     name="CreateUserParameters",
-     *     in="body",
-     *     required=true,
-     *     @SWG\Schema(
-     *     ref="#/definitions/CreateUserRequest"
-     *     )
-     *   ),
-     *   @SWG\Response(
-     *     response=200,
-     *     description="Email and usertoken"
-     *   ),
-     *   @SWG\Response(
-     *     response=500,
-     *     description="Database or Core Api Error"
-     *   )
-     * )
      */
     public function create(CreateUserRequest $request)
     {

--- a/app/Http/Requests/CreateUserRequest.php
+++ b/app/Http/Requests/CreateUserRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use App\Rules\IsSupportedLanguage;
 
 class CreateUserRequest extends FormRequest
 {
@@ -37,6 +38,7 @@ class CreateUserRequest extends FormRequest
             'first_name'    => 'required',
             'last_name'     => 'required',
             'org_size_id'   => 'integer|min:1|max:7',
+            'preferred_language' => new IsSupportedLanguage(),
         ];
     }
 }

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\Exceptions\HttpResponseException;
+use App\Rules\IsSupportedLanguage;
 
 class UpdateUserRequest extends FormRequest
 {
@@ -46,7 +47,7 @@ class UpdateUserRequest extends FormRequest
             'org_industry'  => '',
             'org_phone'     => '',
             'org_size_id'   => 'integer',
-            'preferred_language' => 'string|size:2',
+            'preferred_language' => new IsSupportedLanguage(),
         ];
     }
 }

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -46,6 +46,7 @@ class UpdateUserRequest extends FormRequest
             'org_industry'  => '',
             'org_phone'     => '',
             'org_size_id'   => 'integer',
+            'preferred_language' => 'string|size:2',
         ];
     }
 }

--- a/app/Rules/IsSupportedLanguage.php
+++ b/app/Rules/IsSupportedLanguage.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class IsSupportedLanguage implements Rule
+{
+    protected $supportedLanguages = ['de', 'en'];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if(in_array($value, $this->supportedLanguages))
+            return true;
+
+        return false;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The language you want to set is not supported.';
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -11,6 +11,7 @@ class User extends Authenticatable
 
     protected $fillable = [
         'name', 'email', 'salutation_id', 'first_name', 'last_name', 'address', 'plz', 'city', 'phone', 'org_name', 'org_industry', 'org_address', 'org_plz', 'org_city', 'org_phone', 'acl_id', 'org_size_id', 'agb',
+        'preferred_language',
     ];
 
     protected $hidden = [

--- a/database/migrations/2017_12_17_162413_update_foreign_keys.php
+++ b/database/migrations/2017_12_17_162413_update_foreign_keys.php
@@ -30,7 +30,7 @@ class UpdateForeignKeys extends Migration
         });
 
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('org_size_id')->unsigned();
+            $table->integer('org_size_id')->unsigned()->nullable();
             $table->foreign('org_size_id')->references('id')->on('org_size');
         });
     }

--- a/database/migrations/2018_12_03_141216_add_preferred_language_field_to_users_table.php
+++ b/database/migrations/2018_12_03_141216_add_preferred_language_field_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddPreferredLanguageFieldToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('preferred_language', 191)->default('de');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('preferred_language');
+        });
+    }
+}

--- a/tests/Feature/SiwecosUserControllerTest.php
+++ b/tests/Feature/SiwecosUserControllerTest.php
@@ -44,8 +44,9 @@ class SiwecosUserControllerTest extends TestCase
                 'acl_id'       => 1,
                 'active'       => 1,
                 'org_city'     => 'Frankfurt',
-                'password'     => 'notMissingAnymore', ]);
+            ]);
         $testUser->token = 'TEST_CASE_DUMMY_TOKEN';
+        $testUser->password = \Hash::make('securePassword');
         $testUser->save();
         $this->testUserId = $testUser->id;
         $this->token = $testUser->token;

--- a/tests/Feature/UserChangePreferredLanguageTest.php
+++ b/tests/Feature/UserChangePreferredLanguageTest.php
@@ -37,4 +37,18 @@ class UserChangePreferredLanguageTest extends TestCase
         $this->assertEquals(422, $response->getStatusCode());
         $this->assertEquals('de', User::first()->preferred_language);
     }
+
+    /** @test */
+    public function only_supported_languages_are_accepted()
+    {
+        $this->getTestUser(true);
+        $token = User::first()->token;
+
+        $response = $this->post('/api/v1/users/updateUserData', [
+            'preferred_language' => 'xx'
+        ], ['userToken' => $token]);
+
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertEquals('de', User::first()->preferred_language);
+    }
 }

--- a/tests/Feature/UserChangePreferredLanguageTest.php
+++ b/tests/Feature/UserChangePreferredLanguageTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\User;
+
+class UserChangePreferredLanguageTest extends TestCase
+{
+
+    /** @test */
+    public function the_users_preferredLanguage_can_be_changed()
+    {
+        $this->getTestUser(true);
+        $token = User::first()->token;
+
+        $response = $this->post('/api/v1/users/updateUserData', [
+            'preferred_language' => 'en'
+        ], ['userToken' => $token]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('en', User::first()->preferred_language);
+    }
+
+    /** @test */
+    public function the_users_preferredLanguage_should_always_be_2_chars()
+    {
+        $this->getTestUser(true);
+        $token = User::first()->token;
+
+        $response = $this->post('/api/v1/users/updateUserData', [
+            'preferred_language' => 'english'
+        ], ['userToken' => $token]);
+
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertEquals('de', User::first()->preferred_language);
+    }
+}

--- a/tests/Feature/UserChangePreferredLanguageTest.php
+++ b/tests/Feature/UserChangePreferredLanguageTest.php
@@ -9,6 +9,7 @@ use App\User;
 
 class UserChangePreferredLanguageTest extends TestCase
 {
+    use RefreshDatabase;
 
     /** @test */
     public function the_users_preferredLanguage_can_be_changed()

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\User;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function a_user_has_a_preferredLanguage_field_with_default_de()
+    {
+        $this->getTestUser(true);
+        $user = User::first();
+
+        $this->assertEquals('de', $user->preferred_language);
+    }
+}


### PR DESCRIPTION
Die Sprachauswahl ist nun eingebaut und kann gespeichert werden.

Beim Anlegen eines Nutzers wird standardmäßig die Sprache Deutsch `de` ausgewählt.

Die Sprache kann geändert werden, via `UpdateUserDataRequest` an: `/api/v1/users/updateUserData` mit Feld `preferred_language`.

Die `preferred_language` soll ein String aus 2 Zeichen sein: `de` oder `en`.

-----------------

Notwendige Anpassungen an der Webapp siehe unten.