### PR TITLE
Zeitanpassung bis Domain deverifiziert wird

### DIFF
--- a/app/Http/Controllers/CrawlerController.php
+++ b/app/Http/Controllers/CrawlerController.php
@@ -43,11 +43,9 @@ class CrawlerController extends Controller
             }
 
             Cache::forget('domain-' . $domain->id . '-couldNotCrawl');
-        }
-
-        if ($request->json('hasError') === false && $request->json('httpCouldConnect') === false) {
+        } else {
             Cache::increment('domain-' . $domain->id . '-couldNotCrawl');
-            if (Cache::get('domain-' . $domain->id . '-couldNotCrawl') === 7) {
+            if (Cache::get('domain-' . $domain->id . '-couldNotCrawl') === 2) {
                 $domain->update(['is_verified' => false]);
             }
         }

--- a/app/Http/Controllers/CrawlerController.php
+++ b/app/Http/Controllers/CrawlerController.php
@@ -45,7 +45,7 @@ class CrawlerController extends Controller
             Cache::forget('domain-' . $domain->id . '-couldNotCrawl');
         } else {
             Cache::increment('domain-' . $domain->id . '-couldNotCrawl');
-            if (Cache::get('domain-' . $domain->id . '-couldNotCrawl') === 2) {
+            if (Cache::get('domain-' . $domain->id . '-couldNotCrawl') === 7) {
                 $domain->update(['is_verified' => false]);
             }
         }


### PR DESCRIPTION
Kann eine Domain nicht gecrawled werden, soll sie nach einer gewissen Zeit als `is_verified: false` markiert werden, sodass für diese nicht mehr die täglichen Scans gestartet werden.

Diese würden ohnehin lediglich Fehler melden.

Die beiden Änderungen umfassen nun die Anpassung, dass auch bei anderen Crawler-Fehlern die Domain entsprechend nach ein paar Tagen deverifiziert wird und ist nun effizienter.