### PR TITLE
Anpassung Scan-Intervall für MailDomain

### DIFF
--- a/app/SiwecosScan.php
+++ b/app/SiwecosScan.php
@@ -196,7 +196,7 @@ class SiwecosScan extends Model
 
             foreach ($this->domain->mailDomains as $mailDomain) {
                 $latestScan = $mailDomain->latestScan;
-                if ($latestScan && !$latestScan->has_error && $latestScan->created_at->gte(now()->subHours(6))) {
+                if ($latestScan && !$latestScan->has_error && $latestScan->created_at->gte(now()->subWeek())) {
                     $this->scans()->syncWithoutDetaching($latestScan);
                 } else {
                     $scan = $this->scans()->create(['url' => $mailDomain->domain]);


### PR DESCRIPTION
Reduziert die Last auf dem Server.

Tägliche Scans nicht notwendig, da sich hier ohnehin nur wenig ändern wird.